### PR TITLE
Replace literal nbsp with &nbsp; and add &nbsp; in place names

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -21,11 +21,11 @@ const posts = (await getCollection("posts"))
             </p>
             <p>
                 In 2024, I graduated from UC Berkeley, where I studied
-                computer science and public policy.
+                computer&nbsp;science and public&nbsp;policy.
             </p>
             <p>
-                I was born in North Carolina and grew up in New Delhi, India. I
-                now live in San Francisco, California.
+                I was born in North&nbsp;Carolina and grew up in New&nbsp;Delhi, India. I
+                now live in San&nbsp;Francisco, California.
             </p>
         </section>
 


### PR DESCRIPTION
Converts two literal non-breaking space characters (in "computer science"
and "public policy") to &nbsp; entities, and adds &nbsp; between words
in multi-word place names (North Carolina, New Delhi, San Francisco) so
they render as single units without line breaks.